### PR TITLE
Revert "Check how many mirrors are activated"

### DIFF
--- a/modfiles/AdjustableMirrors_Register.lua
+++ b/modfiles/AdjustableMirrors_Register.lua
@@ -34,33 +34,30 @@ FS_Debug.log_level_max = 1
 --### being drivable, before adding the AdjustableMirrors specialization.
 --#######################################################################################
 if g_specializationManager:getSpecializationByName("AdjustableMirrors") == nil then
-	FS_Debug.info("maxNumMirrors: " .. g_gameSettings:getValue("maxNumMirrors"))
-	if g_gameSettings:getValue("maxNumMirrors") > 0 then -- Register only if at least one mirror is activated in settings
-		if AdjustableMirrors == nil then
-			FS_Debug.error("Unable to find specialization '" .. "AdjustableMirrors" .. "'");
-		else
-			--Go through the different vehicle types and see if they meet the criteria required for adjustable mirrors
-			for i, typeDef in pairs(g_vehicleTypeManager.vehicleTypes) do
-				--Sort out nil keys and trains, since we don't need to adjust mirrors on trains
-				if typeDef ~= nil and i ~= "locomotive" then
-					local isDrivable = false
-					local isEnterable = false
-					local hasMotor = false
-					for name, spec in pairs(typeDef.specializationsByName) do
-						if name == "drivable" then
-							isDrivable = true
-						elseif name == "motorized" then
-							hasMotor = true
-						elseif name == "enterable" then
-							isEnterable = true
-						end
+	if AdjustableMirrors == nil then
+		FS_Debug.error("Unable to find specialization '" .. "AdjustableMirrors" .. "'");
+	else
+		--Go through the different vehicle types and see if they meet the criteria required for adjustable mirrors
+		for i, typeDef in pairs(g_vehicleTypeManager.vehicleTypes) do
+			--Sort out nil keys and trains, since we don't need to adjust mirrors on trains
+			if typeDef ~= nil and i ~= "locomotive" then
+				local isDrivable = false
+				local isEnterable = false
+				local hasMotor = false
+				for name, spec in pairs(typeDef.specializationsByName) do
+					if name == "drivable" then
+						isDrivable = true
+					elseif name == "motorized" then
+						hasMotor = true
+					elseif name == "enterable" then
+						isEnterable = true
 					end
-					if isDrivable and isEnterable and hasMotor then
-						FS_Debug.info("Attached specialization " .. "'" .. "AdjustableMirrors" .. "'" .. "to vehicleType '" .. tostring(i) .. "'")
-						typeDef.specializationsByName["AdjustableMirrors"] = AdjustableMirrors
-						table.insert(typeDef.specializationNames, "AdjustableMirrors")
-						table.insert(typeDef.specializations, AdjustableMirrors)
-					end
+				end
+				if isDrivable and isEnterable and hasMotor then
+					FS_Debug.info("Attached specialization " .. "'" .. "AdjustableMirrors" .. "'" .. "to vehicleType '" .. tostring(i) .. "'")
+					typeDef.specializationsByName["AdjustableMirrors"] = AdjustableMirrors
+					table.insert(typeDef.specializationNames, "AdjustableMirrors")
+					table.insert(typeDef.specializations, AdjustableMirrors)
 				end
 			end
 		end


### PR DESCRIPTION
Reverts StjerneIdioten/AdjustableMirrors#32 

I found out that it actually does more harm than good to do that check since it causes synchronization errors on the server! If fx. the server receives a mirror change from another client and tries to push it to the client without mirrors, the script wont be there to read the data and therefor throw the client out of synch! Might be able to use the code for a SP only check though.